### PR TITLE
WIP: stop zone playback when Music Assistant ends the stream (pause)

### DIFF
--- a/src/adapters/inputs/musicassistant/musicAssistantStreamService.ts
+++ b/src/adapters/inputs/musicassistant/musicAssistantStreamService.ts
@@ -49,6 +49,12 @@ function toPlayerId(zoneName: string, fallbackId: number): string {
   return `lox-${normalized || fallbackId}`;
 }
 
+// MA ends the stream both to pause/stop and on a track change. On a track change a
+// new stream/start follows almost immediately, so wait this long before treating a
+// stream end as a real stop. Long enough to bridge a gapless transition, short enough
+// that a pause feels immediate.
+const MA_STREAM_STOP_DEBOUNCE_MS = 1000;
+
 // Collapse a player id to its alphanumeric slug for matching across MA's id transforms.
 // `lox-audio-player-2` -> `loxaudioplayer2`; MA's universal_player wraps it as
 // `up` + slug -> `uploxaudioplayer2`.
@@ -106,6 +112,8 @@ export class MusicAssistantStreamService {
     onSwitchAway?: (zoneId: number) => void;
   } = {};
   private lastPlayIntentAt = new Map<number, number>();
+  /** Debounced stop-on-stream-end timers, cancelled when a new stream/start arrives. */
+  private pendingStreamStopTimers = new Map<number, NodeJS.Timeout>();
   // Tracks in-flight serviceplay requests so sendspin doesn't double-start playback.
   private pendingStreamRequests = new Map<number, number>();
   private streamRequestSeq = 0;
@@ -1280,6 +1288,8 @@ export class MusicAssistantStreamService {
     if (!this.inputHandlers?.startPlayback) {
       return;
     }
+    // A stream is (re)starting: this was a track change or a resume, not a pause.
+    this.cancelPendingStreamStop(zoneId);
     this.lastStreamStartAt.set(zoneId, Date.now());
     const meta = this.lastMetadata.get(zoneId);
     const source: PlaybackSource = {
@@ -1329,26 +1339,45 @@ export class MusicAssistantStreamService {
     this.inputHandlers.startPlayback(zoneId, 'musicassistant', source, metadata);
   }
 
+  /**
+   * MA has no player pause command: it pauses/stops by ending the stream. A track
+   * change ends the stream too, but a fresh `stream/start` follows within
+   * milliseconds — so debounce and only stop when nothing resumes.
+   *
+   * Deliberately does NOT gate on `playingState` / `recentPlayIntent`: MA never
+   * reports a paused state to us, so `playingState` stays `true` forever and would
+   * block every stop, and `recentPlayIntent` would swallow a pause pressed shortly
+   * after play. The debounce is the reliable discriminator.
+   */
   private handleInputStreamStop(zoneId: number, playerId: string): void {
     if (!this.inputHandlers?.stopPlayback) {
       return;
     }
-    if (this.playingState.get(zoneId) === true) {
-      this.log.debug('music assistant stream stop ignored; MA still playing', {
-        zoneId,
-        playerId,
-      });
-      return;
+    this.cancelPendingStreamStop(zoneId);
+    const timer = setTimeout(() => {
+      this.pendingStreamStopTimers.delete(zoneId);
+      this.playingState.set(zoneId, false);
+      this.log.info('music assistant input stream stop', { zoneId, playerId });
+      this.inputHandlers?.stopPlayback?.(zoneId);
+    }, MA_STREAM_STOP_DEBOUNCE_MS);
+    if (typeof timer.unref === 'function') {
+      timer.unref();
     }
-    if (this.recentPlayIntent(zoneId, 6000)) {
-      this.log.debug('music assistant stream stop ignored; recent play intent', {
-        zoneId,
-        playerId,
-      });
-      return;
+    this.pendingStreamStopTimers.set(zoneId, timer);
+    this.log.debug('music assistant stream end; stop scheduled', {
+      zoneId,
+      playerId,
+      delayMs: MA_STREAM_STOP_DEBOUNCE_MS,
+    });
+  }
+
+  /** A new stream started (resume or next track) — abort a scheduled stop. */
+  private cancelPendingStreamStop(zoneId: number): void {
+    const pending = this.pendingStreamStopTimers.get(zoneId);
+    if (pending) {
+      clearTimeout(pending);
+      this.pendingStreamStopTimers.delete(zoneId);
     }
-    this.log.info('music assistant input stream stop', { zoneId, playerId });
-    this.inputHandlers?.stopPlayback?.(zoneId);
   }
 
   private handleInputMetadata(zoneId: number, playerId: string, metadata: PlaybackMetadata): void {

--- a/src/adapters/inputs/musicassistant/sendspinClient.ts
+++ b/src/adapters/inputs/musicassistant/sendspinClient.ts
@@ -355,6 +355,18 @@ export class SendspinClient {
       this.resetStreamState();
       this.streamFormat = null;
       this.log.info('sendspin stream cleared', { playerId: this.playerId, type: msg.type });
+      // MA signals pause/stop by ending the stream (there is no player pause command).
+      // Propagate it so the zone's playback is actually stopped — without this the
+      // input stream is cleared but the zone keeps playing. handleInputStreamStop
+      // guards against a track-change stream/end (recent play intent / MA still playing).
+      try {
+        this.onStream?.stop?.(this.zoneId, this.playerId);
+      } catch (err) {
+        this.log.debug('sendspin stream stop dispatch failed', {
+          playerId: this.playerId,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
       return;
     }
     if (msg.type === 'metadata') {


### PR DESCRIPTION
## Problem

Pressing **pause** in Music Assistant has no audible effect on a Loxone zone — the music keeps playing.

Music Assistant has **no player pause command**: the Sendspin `PlayerCommand` enum is exhaustively `{VOLUME, MUTE, SET_STATIC_DELAY}` (aiosendspin `models/types.py`), and `music_assistant/providers/sendspin/player.py` implements only `volume_set` / `volume_mute` / `stop` / `play_media`. **MA pauses (and stops) a Sendspin player by ending the stream** (`stream/end`).

`SendspinClient.handleJsonMessage()` handled `stream/end` by resetting its own local stream state and returning — it **never invoked the `stop` handler**, even though the handler is wired at construction:

```ts
stop: (zId, pId) => this.handleInputStreamStop(zId, pId),
```

So `handleInputStreamStop()` was effectively dead code and `inputHandlers.stopPlayback()` never ran. The input stream got cleared, but the zone's audio session kept running.

## Change

- **`sendspinClient.ts`** — dispatch `onStream.stop()` on `stream/clear` / `stream/end`.
- **`musicAssistantStreamService.ts`** — `handleInputStreamStop()` now **debounces** the stop (1s) and a new `stream/start` cancels a pending stop.

### Why the existing guards had to go

`handleInputStreamStop()` guarded on `playingState` and `recentPlayIntent`. Neither can work on this path:

- **`playingState === true` blocks forever.** MA never reports a paused state to us — captured live, a pause produces only `stream/end` + `group/update`, no state event — so `playingState` stays `true` and every stop is swallowed (`music assistant stream stop ignored; MA still playing`).
- **`recentPlayIntent(6000)` swallows a legitimate pause.** Measured: play at `14:05:40`, pause at `14:05:46` — exactly 6.0 s, right at the boundary.

A **track change also ends the stream**, but a fresh `stream/start` follows within milliseconds. So the debounce is the reliable discriminator between "paused / stopped" and "next track", without depending on state MA doesn't send.

## Verified on hardware

Against a live Music Assistant, on a Loxone zone with a real connected speaker (`room_kinderzimmer_linda`). From the captured log:

```
14:22:06.806  stream/end        -> stop scheduled
14:22:07.807  input stream stop -> audio session stopped -> Sendspin stop      # pause: audio stops
14:22:35.274  stream/start      -> playback started                            # resume
14:22:40.921  stream/end        -> stop scheduled
14:22:40.933  stream/start (+12ms, "Kapitel 03") -> stop cancelled -> Sendspin play
14:22:41.140  first audio chunk (gen=3)                                        # next: audio continues
```

- **pause** → `stream/end`, no restart → stop fires after 1 s, audio stops ✅
- **next** → `stream/end`, `stream/start` +12 ms → stop cancelled, playback continues, no dropout ✅
- **resume** → `stream/start` → playback restarts ✅

## Notes / open points (hence WIP)

- The **1 s debounce** is a tradeoff: long enough to bridge a gapless transition, short enough that pause feels immediate. If MA can take longer than 1 s to start the next track on slower providers, that value may need raising (or the stop should pause rather than tear down the session). Feedback welcome on the right bound.
- Only the `stream/end` path is touched; `handleInputStreamStop()` was previously unreachable, so no existing flow changes behaviour.
- `recentPlayIntent()` is still used by the `handleMaEvent` STOP path and is left untouched.
