### PR TITLE
WIP: bootstrap Spotify Connect credentials via Zeroconf (fix INVALID_CREDENTIALS, #333)

### DIFF
--- a/src/adapters/content/providers/spotify/serviceAuth.ts
+++ b/src/adapters/content/providers/spotify/serviceAuth.ts
@@ -9,6 +9,7 @@ import { consumePkceVerifier } from '@/adapters/content/providers/spotify/pkce';
 import { resolveSpotifyClientId } from '@/adapters/content/providers/spotify/utils';
 import {
   generateLibrespotCredentialsFromOAuth,
+  pairLibrespotCredentialsViaZeroconf,
 } from '@/adapters/inputs/spotify/spotifyStreamingService';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
@@ -259,6 +260,82 @@ export async function handleSpotifyLibrespotOAuth(
     log.warn('librespot oauth credential generation failed', { accountId, message });
     res.writeHead(500, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'librespot_oauth_failed', message }));
+  }
+}
+
+/**
+ * Bootstrap librespot credentials for an account via a Zeroconf handshake.
+ * Request (POST): /admin/api/spotify/librespot/zeroconf { accountId, deviceName?, timeoutMs? }
+ * Advertises a temporary Spotify Connect device; the request resolves once the user
+ * selects it in the Spotify app (or the timeout elapses). The returned stored-credentials
+ * blob is persisted as the account's librespotCredentials. This is the only auth path
+ * Spotify still accepts after its 2026-08 access-token change (see #333).
+ */
+export async function handleSpotifyLibrespotZeroconf(
+  req: IncomingMessage,
+  res: ServerResponse,
+  configPort: ConfigPort,
+  spotifyInputService: SpotifyInputService,
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.writeHead(405, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'method_not_allowed' }));
+    return;
+  }
+
+  const body = (await readJsonBody(req)) as
+    | { accountId?: string; deviceName?: string; timeoutMs?: number }
+    | null;
+  const accountId = (body?.accountId || '').trim();
+  const deviceName = (body?.deviceName || '').trim() || `${accountId || 'lox'} (pairing)`;
+  const timeoutMs =
+    typeof body?.timeoutMs === 'number' && Number.isFinite(body.timeoutMs)
+      ? Math.max(30_000, Math.min(300_000, body.timeoutMs))
+      : 120_000;
+
+  if (!accountId) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'missing_account' }));
+    return;
+  }
+
+  const cfg = configPort.getConfig();
+  const account = cfg.content?.spotify?.accounts?.find(
+    (acc) =>
+      acc.id === accountId ||
+      acc.user === accountId ||
+      acc.email === accountId ||
+      acc.spotifyId === accountId,
+  );
+  if (!account) {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'account_not_found' }));
+    return;
+  }
+
+  try {
+    const deviceId = `lox-pair-${accountId}`.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 63) || 'lox-pair';
+    const result = await pairLibrespotCredentialsViaZeroconf({ deviceId, name: deviceName, timeoutMs });
+    if (!result) {
+      res.writeHead(408, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'zeroconf_pairing_failed' }));
+      return;
+    }
+    let parsed: string | Record<string, unknown> = result.credentials;
+    try {
+      parsed = JSON.parse(result.credentials);
+    } catch {
+      /* keep string */
+    }
+    await pushLibrespotCredentials(spotifyInputService, accountId, parsed);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, username: result.username }));
+    reinitializeSpotifyInputs(configPort, spotifyInputService, 'zeroconf_credentials_updated', accountId);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.warn('zeroconf pairing failed', { accountId, message });
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'librespot_zeroconf_failed', message }));
   }
 }
 

--- a/src/adapters/http/adminApi/spotify/spotifyHandlers.ts
+++ b/src/adapters/http/adminApi/spotify/spotifyHandlers.ts
@@ -13,6 +13,7 @@ import {
   deleteSpotifyAccount,
   handleSpotifyLibrespotExport,
   handleSpotifyLibrespotOAuth,
+  handleSpotifyLibrespotZeroconf,
   handleSpotifyOAuthCallback,
 } from '@/adapters/content/providers/spotify/serviceAuth';
 import type { Route } from '@/adapters/http/adminApi/routeTypes';
@@ -63,6 +64,14 @@ export function buildSpotifyRoutes(deps: SpotifyHandlerDeps): Route[] {
           deps.spotifyInputService,
           deps.spotifyManagerProvider,
         ),
+    },
+    {
+      // Bootstrap credentials via a Zeroconf handshake (the only auth path Spotify
+      // still accepts after its 2026-08 access-token change — see #333).
+      method: 'POST',
+      pattern: /^\/spotify\/librespot\/zeroconf$/,
+      handler: async (req, res) =>
+        handleSpotifyLibrespotZeroconf(req, res, deps.configPort, deps.spotifyInputService),
     },
     {
       // Anchored and GET-only: the pattern used to be an unanchored prefix with no

--- a/src/adapters/inputs/spotify/spotifyInputService.ts
+++ b/src/adapters/inputs/spotify/spotifyInputService.ts
@@ -185,7 +185,11 @@ class SpotifyConnectInstance {
     }
 
     const native = await startNativeConnectHost({
-      credentialsPath: this.credentialsPayload ?? credPath,
+      // Only pass a real credentials blob. Falling back to credPath (a FILE PATH)
+      // makes startNativeConnectHost treat the path string as a JSON blob, so
+      // librespot fails with "invalid credentials json" and the access-token path
+      // is never reached.
+      credentialsPath: this.credentialsPayload ?? '',
       deviceName: deviceId,
       publishName,
       onEvent: (ev) => this.handleNativeEvent(ev),

--- a/src/adapters/inputs/spotify/spotifyStreamingService.ts
+++ b/src/adapters/inputs/spotify/spotifyStreamingService.ts
@@ -28,6 +28,11 @@ type NativeAddon = typeof import('@sonn-audio/node-librespot') & {
   ) => Promise<LibrespotSession | null>;
   startConnectDeviceWithCredentials?: (...args: unknown[]) => Promise<ConnectHandle>;
   startConnectDeviceWithToken?: (...args: unknown[]) => Promise<ConnectHandle>;
+  startZeroconfLogin?: (
+    deviceId: string,
+    name?: string,
+    timeoutMs?: number,
+  ) => Promise<CredentialsResult>;
 };
 type NativeStreamHandle = Pick<StreamHandle, 'stop' | 'sampleRate' | 'channels'>;
 
@@ -172,6 +177,42 @@ export type NativeStreamResult = NativeStreamHandle & {
 /**
  * Use an OAuth access token to obtain a reusable librespot credentials blob.
  */
+/**
+ * Bootstrap librespot credentials via a Zeroconf (Spotify Connect) handshake.
+ *
+ * Since ~2026-08-10 Spotify rejects `login5` auth built from an OAuth access token
+ * whose client id is not the desktop client (INVALID_CREDENTIALS), which kills the
+ * `loginWithAccessToken` / `startConnectDeviceWithToken` path. A real Zeroconf
+ * handshake still works (`AUTHENTICATION_STORED_SPOTIFY_CREDENTIALS`). This advertises
+ * a temporary Connect device; when the user selects it in the Spotify app, librespot
+ * returns a usable stored-credentials blob to persist as `librespotCredentials`.
+ * See librespot-org/librespot#1737, devgianlu/go-librespot#364.
+ */
+export async function pairLibrespotCredentialsViaZeroconf(params: {
+  deviceId: string;
+  name?: string;
+  timeoutMs?: number;
+}): Promise<{ username: string; credentials: string } | null> {
+  const { deviceId, name, timeoutMs } = params;
+  if (typeof addon.startZeroconfLogin !== 'function') {
+    log.warn('native librespot has no startZeroconfLogin; cannot Zeroconf-pair');
+    return null;
+  }
+  try {
+    const result = await addon.startZeroconfLogin(deviceId, name, timeoutMs);
+    const credentials = result?.credentialsJson;
+    if (!credentials) {
+      log.warn('zeroconf pairing returned no credentials payload');
+      return null;
+    }
+    return { username: result.username, credentials };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.warn('zeroconf pairing failed', { message });
+    return null;
+  }
+}
+
 export async function generateLibrespotCredentialsFromOAuth(params: {
   accessToken: string;
   deviceName?: string;


### PR DESCRIPTION
## Problem

Since **~2026-08-10** Spotify rejects `login5` authentication built from an OAuth access token whose client id isn't the desktop client (`INVALID_CREDENTIALS`; `BAD_REQUEST` if the account client id is passed), as prep for their **“Soloist”** launch (blog 2026-08-13). This kills `loginWithAccessToken` / `startConnectDeviceWithToken`, so **every zone's Spotify Connect host fails to start and playback can't authenticate**, while the Web API (browsing) still works.

Affects all librespot-based clients — librespot-org/librespot#1737, devgianlu/go-librespot#364. Tracked here in **#333** (multiple users, all on beta.18 by coincidence of timing). Not a core regression: the credential/connect call args are unchanged vs beta.16 and node-librespot is the same 0.5.2.

A **real Zeroconf/Connect handshake still authenticates** (`AUTHENTICATION_STORED_SPOTIFY_CREDENTIALS`). node-librespot already exports the primitive (`startZeroconfLogin`) — core just never called it.

## Change

- **`spotifyStreamingService.ts`** — `pairLibrespotCredentialsViaZeroconf()` wrapping `startZeroconfLogin` (mirrors `generateLibrespotCredentialsFromOAuth`), plus the addon-interface entry.
- **`serviceAuth.ts`** — `handleSpotifyLibrespotZeroconf`: `POST /admin/api/spotify/librespot/zeroconf { accountId, deviceName?, timeoutMs? }`. Advertises a temporary Connect device, resolves when the user selects it in the Spotify app, persists the returned blob as the account's `librespotCredentials`, and reinitialises the inputs. Mirrors the existing `…/librespot/oauth` handler.
- **`spotifyHandlers.ts`** — registers the route.
- **`spotifyInputService.ts`** — small correctness fix: `credentialsPath: this.credentialsPayload ?? credPath` fell back to `credPath` (a **file path**), which `startNativeConnectHost` then treats as a JSON blob → `invalid credentials json`. Changed to `?? ''` so the intended path runs.

## Verified end-to-end on hardware

Ran the equivalent of the new endpoint (`startZeroconfLogin` → pick device in Spotify app → persist blob). Result: `INVALID_CREDENTIALS` went from **~40/30s → 0** across 11 zones; connect hosts start; playback authenticates again. The returned blob is `auth_type: 1` (stored credentials) — the path Spotify still accepts.

## WIP

- **No admin-UI button yet** — endpoint only. A “Pair Spotify” action in the UI (advertise, prompt “select this device in Spotify”, store the blob) is the natural follow-up; happy to add it.
- One pairing yields an **account-level** blob usable by all zones (same as before Spotify's change).
- Open question: whether to auto-trigger pairing when the token path returns `INVALID_CREDENTIALS`, vs. keep it an explicit user action (I lean explicit — it requires the user to tap the device in the app).

Have a reliable hardware repro; glad to iterate.
