### PR TITLE
WIP: auto re-anchor a sendspin client stuck in error while playing

### DIFF
--- a/src/adapters/outputs/sendspin/sendspinOutput.ts
+++ b/src/adapters/outputs/sendspin/sendspinOutput.ts
@@ -219,6 +219,22 @@ export class SendspinOutput implements ZoneOutput {
    * not — a client that only ever says `synchronized` must still be reported as such.
    */
   private reactedClientState: 'synchronized' | 'error' | 'external_source' | null = null;
+  /**
+   * Auto-recover a stuck client re-anchor (WIP).
+   *
+   * The reference sendspin client re-anchors its own timeline on an audio underflow
+   * ("Audio underflow detected; requesting re-anchor"). When that client-local
+   * re-anchor does not converge — observed after Spotify single-active-device
+   * switching — the room desyncs and plays nothing while ALSA stays RUNNING. The
+   * protocol carries no inbound re-anchor request, so the only signal that reaches
+   * the server is a `state: 'error'` player-state report (and identical repeats are
+   * deduped away here, so we cannot count them — we act on the first transition,
+   * debounced). If the client is still in `error` after the debounce while we
+   * believe we are playing, force a fresh server anchor — what a client restart
+   * does, without the restart.
+   */
+  private clientErrorReanchorTimer: NodeJS.Timeout | null = null;
+  private lastAutoReanchorMs = 0;
   private externalSourceActive = false;
   private restartTimer: NodeJS.Timeout | null = null;
   private bufferedChunks: Array<{ data: Buffer; timestampUs: number }> = [];
@@ -940,6 +956,52 @@ export class SendspinOutput implements ZoneOutput {
     }
   }
 
+  /** Debounce before assuming a reported client error is a stuck re-anchor, not a transient. */
+  private static readonly AUTO_REANCHOR_DEBOUNCE_MS = 4000;
+  /** Minimum gap between forced server re-anchors so a persistently-erroring client is not thrashed. */
+  private static readonly AUTO_REANCHOR_COOLDOWN_MS = 30000;
+
+  /**
+   * See the `clientErrorReanchorTimer` field docs. Acts on the *first* `error`
+   * transition (repeats are deduped upstream), cancels if the client recovers to
+   * `synchronized` within the debounce, and re-anchors at most once per cooldown.
+   *
+   * WIP / unverified: whether the reference client actually reports `state: 'error'`
+   * during this specific underflow storm — and whether a server-side fresh anchor
+   * converges it, or a full client restart is required — still needs a live capture.
+   */
+  private maybeAutoReanchorOnError(state?: string): void {
+    if (state === 'synchronized' && this.clientErrorReanchorTimer) {
+      clearTimeout(this.clientErrorReanchorTimer);
+      this.clientErrorReanchorTimer = null;
+      return;
+    }
+    if (state !== 'error' || this.playbackState !== 'playing' || !this.isOwner()) {
+      return;
+    }
+    if (this.clientErrorReanchorTimer) {
+      return; // a recovery is already pending
+    }
+    this.clientErrorReanchorTimer = setTimeout(() => {
+      this.clientErrorReanchorTimer = null;
+      // Recovered on its own, or no longer playing → nothing to do.
+      if (this.clientState !== 'error' || this.playbackState !== 'playing' || !this.isOwner()) {
+        return;
+      }
+      const now = Date.now();
+      if (now - this.lastAutoReanchorMs < SendspinOutput.AUTO_REANCHOR_COOLDOWN_MS) {
+        return;
+      }
+      this.lastAutoReanchorMs = now;
+      this.log.warn('Sendspin client stuck in error while playing — forcing a fresh anchor', {
+        zoneId: this.zoneId,
+        clientId: this.clientId,
+      });
+      void this.startStream({ preserveAnchor: false });
+    }, SendspinOutput.AUTO_REANCHOR_DEBOUNCE_MS);
+    this.clientErrorReanchorTimer.unref?.();
+  }
+
   private handleClientState(update: { state?: string; volume?: number; muted?: boolean }): void {
     const signature = JSON.stringify({
       state: update.state,
@@ -966,6 +1028,8 @@ export class SendspinOutput implements ZoneOutput {
     if (nextState) {
       this.clientState = nextState;
     }
+    // WIP: recover a client whose own underflow re-anchor never converged.
+    this.maybeAutoReanchorOnError(update.state);
     /*
      * Ignore the client's opening volume report, not merely its first message.
      *


### PR DESCRIPTION
> **WIP — opening for direction, not for merge.** I can't run the build locally
> (container-only), so this is unverified code plus a precise diagnosis. Two open
> questions below need a live capture to answer.

## Symptom

After Spotify **single-active-device** switching (playing zone A, then moving the
Spotify account to zone B and back), the room's sendspin client desyncs and plays
**nothing** — while ALSA reports the substream `RUNNING` and frames keep flowing.
The reference client logs, in its own journal:

```
WARNING:sendspin.audio:Audio underflow detected; requesting re-anchor
```

It re-anchors its **own** timeline. Usually fine — but sometimes that client-local
re-anchor never converges, and the room stays silent until the
`sendspin@room_<x>` **client process is restarted**. Restarting the process is
currently the only known recovery.

## Why the server can barely see it

Walking the hook surface (`sendspinHookRegistry.ts` → `buildCombined`), the
protocol exposes no inbound *re-anchor request* or *underflow* event. The only
signal that could reach the server is a `state: 'error'` **player-state** report
via `onPlayerState` → `handleClientState`. And `handleClientState`'s dedup guard
(`signature === lastClientStateSignature → return`) drops identical repeats — so
the server can't even *count* an error storm; at most it sees the first `error`
transition. Today that transition is only **logged** (`warn`), never acted on.

## What this change does

On the first `error` transition while the output believes it is playing, start a
short debounce (4 s). If the client hasn't recovered to `synchronized` by then,
force a fresh server anchor — `startStream({ preserveAnchor: false })`, which is
what a client restart accomplishes without killing the process — guarded by a
per-output cooldown (30 s) so a persistently-erroring client isn't thrashed. If
the client recovers within the debounce, the timer is cancelled.

Minimal and self-contained: two fields + one guarded helper in `sendspinOutput.ts`.

## Open questions (need a live capture during a real desync)

1. **Does the reference client actually report `state: 'error'` during this
   underflow storm**, or does it keep saying `synchronized` and only log the
   re-anchor client-side? If the latter, the server is blind here and the fix must
   live in the client/protocol (surface an underflow/re-anchor event) rather than
   in lox.
2. **Does a server-side fresh anchor converge the client**, or is a full client
   restart genuinely required? The proven recovery so far is a process restart,
   which is heavier than `startStream`.

Happy to adjust the trigger (state value, debounce, cooldown) or move it entirely
once you confirm the client's reporting behaviour.

## Interim workaround (in the field, working now)

Until this is settled I run an external journald watchdog on the Pi that counts
`requesting re-anchor` warnings per `sendspin@room_*` unit and restarts a client
whose re-anchor is stuck — the process restart being the currently-proven fix.
Reference: https://github.com/tobsch/snappy/tree/master/timelinewatch
