### PR TITLE
fix(soloist): re-adopt a zone that becomes active again with no stream (end-of-track freeze)

### DIFF
--- a/src/adapters/inputs/spotify/soloist/soloistPlaybackService.ts
+++ b/src/adapters/inputs/spotify/soloist/soloistPlaybackService.ts
@@ -492,6 +492,20 @@ export class SoloistPlaybackService {
       return;
     }
 
+    // Just became the active device again, but with nothing carrying our audio.
+    //
+    // The handoff that moved the account away tore this zone's stream down (finishTrack), and coming
+    // back is announced as a `device_changed`, which carries no `status` — so the `status === 'playing'`
+    // adopt below never fires on it. Mid-track that is harmless: the `playing` and `track_changed`
+    // events that follow re-adopt it. But when the switch back lands in the last seconds of a track,
+    // Soloist reaches the track's end before any of those arrive and then sends none, leaving the zone
+    // owner=`queue`, no stream, stuck at end-of-track while Soloist plays on into a pipe nobody reads.
+    // Re-adopting here reopens the pipe so playback is consumed again and advances. See #352.
+    if (event.type === 'device_changed' && !runner.stream) {
+      void this.adoptConnectPlayback(zoneId, event);
+      return;
+    }
+
     // Both lists arrive together on `queue_changed`, unasked after every change. They are what
     // tells a step backwards from a step forwards, and while the app owns the zone they are also
     // the only account anyone here has of what is coming.


### PR DESCRIPTION
Fixes #352 — root cause found and fix verified against the deterministic repro (patched into the running
container's `dist`, reproduced with vs. without).

## Root cause (confirmed by instrumenting `onEvent`)

Logging every `onEvent` call through a switch-back-at-the-boundary showed the exact sequence for the zone:

```
type=device_changed  isActive=false  owner=connect              -> deactivate: owner→queue, currentUri→null,
                                                                    finishTrack (stream destroyed), stopPlayback
… (inactive: position_sync / playback_state status=playing, all isActive=false → inactive branch, no-op) …
type=device_changed  isActive=true   owner=queue  status=undefined  uri=undefined   <- became active again
… then NO further ws events — only Soloist stdout `playing … [3:42 / 3:42]` heartbeats …
```

The reactivation arrives as a `device_changed` with **no `status`**. The only path that re-opens the pipe is
the `status === 'playing'` adopt, so `device_changed` slips past it, and `owner === 'queue'` makes onEvent
return. Mid-track this is harmless — the `playing`/`track_changed` events that follow re-adopt the zone. But
when the switch-back lands in the last seconds, Soloist hits the track end *before* any such event and then
emits none, so the zone is left `owner=queue`, `stream=null`, stuck at end-of-track while Soloist streams into
a pipe nobody reads.

## Fix

Re-adopt on `device_changed` when the device is active again but has no stream:

```ts
if (event.type === 'device_changed' && !runner.stream) {
  void this.adoptConnectPlayback(zoneId, event);
  return;
}
```

(placed right after the `!runner.ws.isActive` block, so `isActive` is already guaranteed true there.)

## Verification

Repro: two Soloist zones on one account; `transfer B` → `seek dur-5s` → `transfer A`.

- **Without fix:** zone A pins at `progress == duration`, `is_playing == true`, never advances.
- **With fix (live in dist):** `FIX reactivation re-adopt` → `the spotify app took this zone over` →
  playback advances (`220/222s "Dass es hier so schön ist"` → `0/130s "Zugabe"` → continues). No freeze.

Control (switch not near the boundary) was unaffected either way.
