### PR TITLE
fix(soloist): apply Spotify-app volume changes to the zone (#344)

### DIFF
--- a/src/adapters/inputs/spotify/soloist/soloistPlaybackService.ts
+++ b/src/adapters/inputs/spotify/soloist/soloistPlaybackService.ts
@@ -492,6 +492,16 @@ export class SoloistPlaybackService {
       return;
     }
 
+    // Volume set from the Spotify app. Soloist sends this only to the device it targets — the active
+    // one — as a dedicated `volume_changed`, so it is safe to apply straight to the zone. The `volume`
+    // that also rides along on every `playback_state` is the account-level value Connect broadcasts to
+    // every device at once, and applying that would pull idle rooms to the playing room's level, so it
+    // is deliberately not read here. Mirrors the librespot backend's `updateVolume`. See #344.
+    if (event.type === 'volume_changed' && typeof event.volume === 'number') {
+      this.controller?.updateVolume(zoneId, event.volume);
+      return;
+    }
+
     // Both lists arrive together on `queue_changed`, unasked after every change. They are what
     // tells a step backwards from a step forwards, and while the app owns the zone they are also
     // the only account anyone here has of what is coming.


### PR DESCRIPTION
Fixes #344 — root cause found and fix verified against a deterministic repro.

## Diagnosis

Confirmed a bug (not by design). With Soloist, `soloistPlaybackService.onEvent()` never reads the volume:
`updateVolume` is wired only in the librespot backend (`spotifyInputService.ts`), and the Soloist path
forwards timing/queue/metadata but not volume.

Instrumenting `onEvent` and changing the app volume via the Web API shows Soloist **does** send it, as a
dedicated event targeted at the active device:

```
type=volume_changed  volume=40  zoneId=5
type=volume_changed  volume=70  zoneId=5
type=volume_changed  volume=20  zoneId=5
```

(The `volume` that also appears on every `playback_state` is the account-level value Connect broadcasts to
*every* device — zones 4/5/6/8/9 all reported `volume=100` at once — so that one must not be applied, or idle
rooms follow the playing room. Only the targeted `volume_changed` is safe.)

## Fix

Handle `volume_changed` in `onEvent` and forward to the zone, mirroring the librespot path:

```ts
if (event.type === 'volume_changed' && typeof event.volume === 'number') {
  this.controller?.updateVolume(zoneId, event.volume);
  return;
}
```

## Verification

Web-API volume `45 → 75 → 30` on a Soloist zone (patched into the running container's `dist`):

- **Before:** the sendspin output client stays at its default; nothing changes on the speaker.
- **After:** the client logs `Server set player volume: 45% / 75% / 30%` — the app volume now reaches the
  speaker.
