### PR TITLE
fix(airplay): unique per-zone RAOP identifier — zones collided, AirPlay hit wrong room (#356)

### DIFF
--- a/src/adapters/inputs/airplay/airplayInstance.ts
+++ b/src/adapters/inputs/airplay/airplayInstance.ts
@@ -835,7 +835,12 @@ function deriveHardwareAddress(sourceMac: string, zoneId: number): string {
     const value = Number.parseInt(slice, 16);
     bytes.push(Number.isFinite(value) ? value : 0);
   }
-  bytes[5] = ((bytes[5] ?? 0) + (zoneId & 0xff)) & 0xff;
+  // The per-zone `sourceMac` values are not guaranteed unique (several zones share
+  // one here), so *adding* zoneId to the base's last byte can land two zones on the
+  // same address — e.g. sourceMac ..68 +zoneId 5 and ..67 +zoneId 6 both yield ..6D,
+  // so Wohnzimmer and Elternbad advertised the same RAOP identifier and AirPlay played
+  // into the wrong room. zoneId is unique, so set the last byte from it directly. #356
+  bytes[5] = zoneId & 0xff;
   return bytes.map((byte) => byte.toString(16).padStart(2, '0')).join(':');
 }
 


### PR DESCRIPTION
Fixes #356 — root cause found and fix verified live (patched into the running container's dist).

## Root cause

`deriveHardwareAddress(sourceMac, zoneId)` in `airplayInstance.ts` builds each zone's RAOP identifier by
**adding `zoneId` to the last byte** of the zone's `sourceMac`:

```ts
bytes[5] = ((bytes[5] ?? 0) + (zoneId & 0xff)) & 0xff;
```

But the per-zone `sourceMac` values are **not unique** — several zones share one (in this install:
`…1067`, `…1068`, `…1069`, `…106A` each appear on two zones). Adding `zoneId` on top then collides whenever
`sourceMacLastByte + zoneId` coincides:

| zone | sourceMac | +zoneId | identifier |
|------|-----------|---------|------------|
| 5 Wohnzimmer | …**1068** | +5 | …106**D** |
| 6 Elternbad  | …**1067** | +6 | …106**D** ⚠️ |
| 9 Küche      | …**106A** | +9 | …107**3** |
| 10 Außenbereich | …**1069** | +10 | …107**3** ⚠️ |

So Wohnzimmer/Elternbad and Küche/Außenbereich each advertised the **same** `_raop._tcp` identifier (only the
port differed). An AirPlay client that selects by identifier lands on whichever resolves first — verified:
streaming to `88AEDD68106D` played into **Elternbad**, not the intended **Wohnzimmer**.

## Fix

`zoneId` is unique per zone, so derive the last byte from it directly rather than adding it to a non-unique
base:

```ts
bytes[5] = zoneId & 0xff;
```

## Verification (dist-patched into the running container)

All 11 zones now advertise distinct identifiers, and every zone shows up in discovery (previously the
colliding ones shadowed each other):

```
…1001 Kinderzimmer Linda   …1005 Wohnzimmer     …1009 Küche
…1002 Kinderzimmer Louise  …1006 Elternbad      …100A Außenbereich
…1004 Esszimmer            …1007 Elternschlafz. …100B Gästebad
                           …1008 Backupküche    …100C Einliegerwohnung
```

Streaming an AirPlay tone to Wohnzimmer's id (`…1005`) now lands in the right room —
`[Input|AirPlay][Wohnzimmer] airplay pcm chunk … zoneId=5`.

(Deeper cleanup out of scope here: the per-zone `sourceMac` values probably shouldn't be assigned with
duplicates in the first place. Making the identifier derive from the unique `zoneId` fixes the user-visible
collision regardless.)
